### PR TITLE
Updates spec to remove warning.

### DIFF
--- a/word-count/example.erl
+++ b/word-count/example.erl
@@ -1,24 +1,25 @@
 -module(word_count).
 -export([count/1]).
 
--spec count(string()) -> dict().
+-spec count(string()) -> dict:dict().
 count(S) ->
-    lists:foldl(fun (K, Acc) -> dict:update_counter(K, 1, Acc) end,
-                dict:new(),
-                tokenize(string:to_lower(S))).
+  lists:foldl(fun (K, Acc) -> dict:update_counter(K, 1, Acc) end,
+              dict:new(),
+              tokenize(string:to_lower(S))).
 
 is_alnum(C) ->
-    (C >= $a andalso C =< $z) orelse (C >= $0 andalso C =< $9).
+  (C >= $a andalso C =< $z) orelse (C >= $0 andalso C =< $9).
 
 is_sep(C) ->
-    not is_alnum(C).
+  not is_alnum(C).
 
 tokenize([]) ->
-    [];
+  [];
 tokenize(S) ->
-    case lists:splitwith(fun is_alnum/1, lists:dropwhile(fun is_sep/1, S)) of
-        {[], Rest} ->
-            tokenize(Rest);
-        {Word, Rest} ->
-            [Word | tokenize(Rest)]
-    end.
+  case lists:splitwith(fun is_alnum/1, lists:dropwhile(fun is_sep/1, S)) of
+    {[], Rest} ->
+      tokenize(Rest);
+    {Word, Rest} ->
+      [Word | tokenize(Rest)]
+  end.
+


### PR DESCRIPTION
When running all the tests for xerlang, I was getting a warning on this file.

Warning was:
```
word_count.erl:4: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
```