### PR TITLE
Add a test to check wrong type

### DIFF
--- a/leap/leap_tests.erl
+++ b/leap/leap_tests.erl
@@ -18,3 +18,7 @@ century_test() ->
 
 fourth_century_test() ->
     ?assert(leap:leap_year(2400)).
+
+wrong_type_test() ->
+    ?assertError(function_clause, leap:leap_year("1996")).
+


### PR DESCRIPTION
I think it's better to have a test case to make sure the call with wrong type will crash a caller.