### PR TITLE
Test behavior, not specific implementation details

### DIFF
--- a/bank-account/bank_account_tests.erl
+++ b/bank-account/bank_account_tests.erl
@@ -11,7 +11,7 @@ close_account_test() ->
   bank_account:deposit( Bank_account, 1 ),
   Amount = bank_account:close( Bank_account ),
   ?assert(Amount =:= 1),
-  ?assertError(function_clause, bank_account:balance( Bank_account )).
+  ?assertEqual({error, account_closed}, bank_account:balance( Bank_account )).
 
 deposit_test() ->
   Bank_account = bank_account:create(),

--- a/bank-account/example.erl
+++ b/bank-account/example.erl
@@ -23,7 +23,9 @@ call( true, Pid, Request, Argument ) ->
   Pid ! {Request, Argument, erlang:self()},
   receive
     {Request, Answer} -> Answer
-  end.
+  end;
+call( false, _Pid, _Request, _Argument ) ->
+  {error, account_closed}.
 
 loop( Balance ) ->
   receive


### PR DESCRIPTION
The current test reflects a specific implementation when it comes to a failure due to an account closure, and that error is unhelpful; instead, make it expect an error that is explicit about the reason for the failure (much better coding practice on both sides).