### PR TITLE
Update `get_students_in_a_non_existant_grade_test`

### DIFF
--- a/grade-school/grade_school_tests.erl
+++ b/grade-school/grade_school_tests.erl
@@ -34,7 +34,7 @@ get_students_in_a_grade_test() ->
   ?assertEqual(["Bradley","Franklin"], lists:sort(Students)).
 
 get_students_in_a_non_existant_grade_test() ->
-  ?assertEqual(grade_school:new(), grade_school:get(1, [])).
+  ?assertEqual([], grade_school:get(1, grade_school:new())).
 
 sort_school_test() ->
   S1 = grade_school:add("Jennifer", 4, grade_school:new()),


### PR DESCRIPTION
The old version of the test in question assumed a) you are using lists to represent your school b) an empty classroom/roster is equal to an empty school.

This change does now introduce complete agnostic about the structure of the school itself. Also now `grade_school:get/2` is expected to always return an ordered list of names.