### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+---
 language: erlang
 otp_release:
-  - 17.4
+- 17.4
 install:
-  - './_test/bootstrap.sh'
+- "./_test/bootstrap.sh"
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
-  - './_test/check-exercises.escript'
+- bin/fetch-configlet
+- bin/configlet .
+- "./_test/check-exercises.escript"
 cache:
-  - apt
+- apt


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.