### PR TITLE
Fix typo for running tests instructions.

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,5 +1,5 @@
 ```bash
 $ erlc bob*.erl
-$ erl -noshell -eval "eunit:test(bob_test, [verbose])" -s init stop
+$ erl -noshell -eval "eunit:test(bob, [verbose])" -s init stop
 ```
 


### PR DESCRIPTION
- EUnit expects test modules to end in _tests. If they do
  (and xerlang's do) then you only need to test the module name
  as per the fix. See "Putting tests in separate modules" at
  http://erlang.org/doc/apps/eunit/chapter.html#Running_EUnit
- The full module test name can be used if this is preferred
  but in this case it would be bob_tests not bob_test.