### PR TITLE
[difference of squares] Lined up tests and examples with x-common/difference_of_squares.json

### DIFF
--- a/difference-of-squares/difference_of_squares_tests.erl
+++ b/difference-of-squares/difference_of_squares_tests.erl
@@ -1,7 +1,42 @@
 -module(difference_of_squares_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-ten_test() ->
-  Sum_of_squares = difference_of_squares:sum_of_squares( 10 ),
-  Square_of_sums = difference_of_squares:square_of_sums( 10 ),
-  ?assert( Square_of_sums - Sum_of_squares =:= 2640 ).
+-define(assertSumOfSquares(Expected, Number), ?assertEqual(Expected, difference_of_squares:sum_of_squares(Number))).
+-define(assertSquareOfSums(Expected, Number), ?assertEqual(Expected, difference_of_squares:square_of_sums(Number))).
+-define(assertDifference(Expected, Number), ?assertEqual(Expected, difference_of_squares:difference_of_squares(Number))).
+
+%% Square the sum of the numbers up to the given number
+
+square_of_sums_5_test() ->
+  ?assertSquareOfSums( 225, 5 ).
+
+square_of_sums_10_test() ->
+  ?assertSquareOfSums( 3025, 10 ).
+
+square_of_sums_100_test() ->
+  ?assertSquareOfSums( 25502500, 100 ).
+
+%% Sum the squares of the numbers up to the given number
+
+sum_of_square_5_test() ->
+  ?assertSumOfSquares( 55, 5 ).
+
+sum_of_square_10_test() ->
+  ?assertSumOfSquares( 385, 10 ).
+
+sum_of_square_100_test() ->
+  ?assertSumOfSquares( 338350, 100 ).
+
+%% Subtract sum of squares from square of sums
+
+difference_of_squares_0_test() ->
+  ?assertDifference( 0, 0 ).
+
+difference_of_squares_5_test() ->
+  ?assertDifference( 170, 5 ).
+
+difference_of_squares_10_test() ->
+  ?assertDifference( 2640, 10 ).
+
+difference_of_squares_100_test() ->
+  ?assertDifference( 25164150, 100 ).

--- a/difference-of-squares/example.erl
+++ b/difference-of-squares/example.erl
@@ -1,11 +1,12 @@
 -module(difference_of_squares).
 
--export( [sum_of_squares/1, square_of_sums/1] ).
+-export( [sum_of_squares/1, square_of_sums/1, difference_of_squares/1] ).
 
 sum_of_squares( N ) -> lists:sum( [square(X) || X <- lists:seq(1, N)] ).
 
 square_of_sums( N ) -> square( lists:sum(lists:seq(1, N)) ).
 
+difference_of_squares( N ) -> square_of_sums( N ) - sum_of_squares( N ).
 
 
 square( N ) -> erlang:trunc( math:pow(N, 2) ).


### PR DESCRIPTION
This includes the following:

* Create 3 dedicated tests for `square_of_sums/1` with arguments 5, 10,
and 100.
* Create 3 dedicated tests for `sum_of_squares/1` with arguments 5, 10,
and 100.
* Create 4 dedicated tests for `difference_of_squares/1` with arguments
0, 5, 10, and 100.
* Implement the function `difference_of_squares/1` in `example.erl`.
* delete the former single test `ten_test` since it is now obselete.