### PR TITLE
Fix typos in triangle

### DIFF
--- a/exercises/triangle/example.erl
+++ b/exercises/triangle/example.erl
@@ -6,7 +6,7 @@ kind(A,B,C) when (A =< 0) or (B =< 0) or (C =< 0) ->
     {error, "all side lengths must be positive"};
 kind(A,B,C) when not ((A < (B + C)) and (B < (A + C)) and (C < (A + B))) ->
     {error, "side lengths violate triangle inequality"};
-kind(A,A,A) -> equiliteral;
+kind(A,A,A) -> equilateral;
 kind(A,_,A) -> isosceles;
 kind(A,A,_) -> isosceles;
 kind(_,B,B) -> isosceles;

--- a/exercises/triangle/triangle_tests.erl
+++ b/exercises/triangle/triangle_tests.erl
@@ -4,11 +4,11 @@
 -module(triangle_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-equiliteral_triangles_have_equal_sides_test() ->
-    ?assertMatch(equiliteral, triangle:kind(2,2,2)).
+equilateral_triangles_have_equal_sides_test() ->
+    ?assertMatch(equilateral, triangle:kind(2,2,2)).
 
-larger_equiliteral_triangles_also_have_equal_sides_test() ->
-    ?assertMatch(equiliteral, triangle:kind(10, 10, 10)).
+larger_equilateral_triangles_also_have_equal_sides_test() ->
+    ?assertMatch(equilateral, triangle:kind(10, 10, 10)).
 
 isosceles_triangles_have_at_least_two_sides_equal_test() ->
     ?assertMatch(isosceles, triangle:kind(3, 4, 4)).


### PR DESCRIPTION
Correct the misspelling of "equilateral" in the tests and example.