### PR TITLE
Classified some exercises as `foregone` in `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,6 +47,8 @@
     "_test"
   ],
   "foregone": [
-
+    "binary-search",
+    "lens-person",
+    "linked-list"
   ]
 }


### PR DESCRIPTION
I wnet through http://exercism.io/languages/erlang/contribute and sorted out items not suitable for erlang track:

* `binary-search`: A binary search over linked lists is less efficient
  than a linear scan. Even if we could use the `array`-module, I don't
  think we should encourage it.
* `lens-person`: In the exercises description it is clearly stated that
  it is specific to haskell.
* `linked-list`: despite the name, this exercise is about doubly-linked
  lists which simply can't exist in a language that is strictly
  immutable as erlang.

Perhaps I might missed some.

The exercises went to `foregone`-key, because thats how I do understand the description given in [x-common/CONTRIBUTING.md#configjson](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#configjson)