### PR TITLE
Zipper

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,7 +37,8 @@
     "meetup",
     "parallel-letter-frequency",
     "triangle",
-    "scrabble-score"  
+    "scrabble-score",
+    "zipper"
   ],
   "deprecated": [
 

--- a/exercises/zipper/example.erl
+++ b/exercises/zipper/example.erl
@@ -1,0 +1,84 @@
+-module(zipper).
+
+-export([new_tree/3, empty/0]).
+
+-export([from_tree/1, to_tree/1, up/1, left/1, right/1, value/1, set_value/2, set_left/2, set_right/2]).
+
+-export_type([tree/0, zipper/0]).
+
+-record(tree, {value       :: any(),
+               left  = nil :: tree(),
+               right = nil :: tree()}).
+
+-record(zipper, {value       :: any(),
+                 left  = nil :: tree(),
+                 right = nil :: tree(),
+                 trail = []  :: list({left | right, any(), tree()})}).
+
+-opaque tree()   :: nil | #tree{}.
+-opaque zipper() :: #zipper{}.
+
+%% Tree API
+%% ========
+
+new_tree(Value, Left, Right) ->
+    #tree{value = Value,
+          left  = Left,
+          right = Right}.
+
+empty() -> nil.
+
+%% Zipper API
+%% ==========
+
+from_tree(BTree) ->
+    #zipper{value = BTree#tree.value,
+            left  = BTree#tree.left,
+            right = BTree#tree.right}.
+
+to_tree(Z = #zipper{trail = [_|_]}) -> to_tree(up(Z));
+to_tree(Z = #zipper{trail = []}) ->
+    new_tree(Z#zipper.value, Z#zipper.left, Z#zipper.right).
+
+up(#zipper{trail = []}) -> empty();
+up(Z = #zipper{trail = [{left, V, R}|T]}) ->
+    #zipper{value = V,
+            left  = new_tree(Z#zipper.value, Z#zipper.left, Z#zipper.right),
+            right = R,
+            trail = T};
+up(Z = #zipper{trail = [{right, V, L}|T]}) ->
+    #zipper{value = V,
+            left  = L,
+            right = new_tree(Z#zipper.value, Z#zipper.left, Z#zipper.right),
+            trail = T}.
+
+left(#zipper{left = nil}) -> nil;
+left(Z = #zipper{}) ->
+    Next = Z#zipper.left,
+    #zipper{value = Next#tree.value,
+            left  = Next#tree.left,
+            right = Next#tree.right,
+            trail = [{left, Z#zipper.value, Z#zipper.right}|Z#zipper.trail]}.
+
+right(#zipper{right = nil}) -> nil;
+right(Z = #zipper{}) ->
+    Next = Z#zipper.right,
+    #zipper{value = Next#tree.value,
+            left  = Next#tree.left,
+            right = Next#tree.right,
+            trail = [{right, Z#zipper.value, Z#zipper.left}|Z#zipper.trail]}.
+
+value(#zipper{value = V}) -> V.
+
+set_value(Z = #zipper{}, V) ->
+    Z#zipper{value = V}.
+
+set_left(Z = #zipper{}, L) ->
+    Z#zipper{left = L}.
+
+set_right(Z = #zipper{}, R) ->
+    Z#zipper{right = R}.
+
+%% Local Variables:
+%% erlang-check-module-name: nil
+%% End:

--- a/exercises/zipper/hints/README.md
+++ b/exercises/zipper/hints/README.md
@@ -1,0 +1,2 @@
+This directory contains some hints to help you complete this exercise. The
+higher the number of a hint file, the more explicit the hint.

--- a/exercises/zipper/hints/hint_1.md
+++ b/exercises/zipper/hints/hint_1.md
@@ -1,0 +1,1 @@
+The difficult part is not getting there, but to remember how you got there.

--- a/exercises/zipper/hints/hint_2.md
+++ b/exercises/zipper/hints/hint_2.md
@@ -1,0 +1,2 @@
+Keep a trail of what choices you mase. Be sure to include alternative branches,
+lest you forget them.

--- a/exercises/zipper/hints/hint_3.md
+++ b/exercises/zipper/hints/hint_3.md
@@ -1,0 +1,16 @@
+```erl
+-type trail :: {left,  any(), tree(), trail()}
+             | {right, any(), tree(), trail()}
+             | top.
+```
+
+or
+
+```erl
+-type trail :: list({left, any(), tree()} | {right, any(), tree()}).
+```
+
+The immediate parent should be the easiest to access.
+
+A zipper record contains the nodes value, left branch right branch and the
+trail.

--- a/exercises/zipper/zipper_tests.erl
+++ b/exercises/zipper/zipper_tests.erl
@@ -1,0 +1,103 @@
+% To run tests:
+% erl -make
+% erl -noshell -eval "eunit:test(zipper, [verbose])" -s init stop
+
+-module(zipper_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Fixtures and helpers
+
+%% defp bt(value, left, right), do: %BT{value: value, left: left, right: right}
+%% defp leaf(value), do: %BT{value: value}
+
+bt(V, L, R) -> zipper:new_tree(V, L, R).
+empty() -> zipper:empty().
+leaf(V) -> zipper:new_tree(V, empty(), empty()).
+
+
+t1() -> bt(1, bt(2, empty(), leaf(3)), leaf(4)).
+t2() -> bt(1, bt(5, empty(), leaf(3)), leaf(4)).
+t3() -> bt(1, bt(2, leaf(5), leaf(3)), leaf(4)).
+t4() -> bt(1, leaf(2),                 leaf(4)).
+t5() -> bt(1, bt(2, nil, leaf(3)), bt(6, leaf(7), leaf(8))).
+t6() -> bt(1, bt(2, nil,     leaf(5)), leaf(4)).
+
+data_is_retained_test() ->
+    Exp = t1(),
+    ?assertMatch(Exp, zipper:to_tree(zipper:from_tree(t1()))).
+
+left_right_and_value_test() ->
+    ?assertMatch(3, zipper:value(zipper:right(zipper:left(zipper:from_tree(t1()))))).
+
+dead_end_test() ->
+    Exp = empty(),
+    ?assertMatch(Exp, zipper:left(zipper:left(zipper:from_tree(t1())))).
+
+tree_from_deep_focus_test() ->
+    Exp = t1(),
+    Zipper = zipper:right(zipper:left(zipper:from_tree(t1()))),
+    ?assertMatch(Exp, zipper:to_tree(Zipper)).
+
+traversing_up_from_top_test() ->
+    Exp = empty(),
+    ?assertMatch(Exp, zipper:up(zipper:from_tree(t1()))).
+
+left_right_and_up_test() ->
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:up(Act1),
+    Act3 = zipper:right(Act2),
+    Act4 = zipper:up(Act3),
+    Act5 = zipper:left(Act4),
+    Act6 = zipper:right(Act5),
+    ?assertMatch(3, zipper:value(Act6)).
+
+set_value_test() ->
+    Exp  = t2(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:set_value(Act1, 5),
+    Act3 = zipper:to_tree(Act2),
+    ?assertMatch(Exp, Act3).
+
+set_value_after_traversiing_up_test() ->
+    Exp  = t2(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:right(Act1),
+    Act3 = zipper:up(Act2),
+    Act4 = zipper:set_value(Act3, 5),
+    Act5 = zipper:to_tree(Act4),
+    ?assertMatch(Exp, Act5).
+
+set_left_with_leaf_test() ->
+    Exp  = t3(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:set_left(Act1, leaf(5)),
+    Act3 = zipper:to_tree(Act2),
+    ?assertMatch(Exp, Act3).
+
+set_right_with_empty_test() ->
+    Exp  = t4(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:set_right(Act1, empty()),
+    Act3 = zipper:to_tree(Act2),
+    ?assertMatch(Exp, Act3).
+
+set_right_with_subtree_test() ->
+    Exp  = t5(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:set_right(Act0, bt(6, leaf(7), leaf(8))),
+    Act2 = zipper:to_tree(Act1),
+    ?assertMatch(Exp, Act2).
+
+set_value_from_deep_focus_test() ->
+    Exp  = t6(),
+    Act0 = zipper:from_tree(t1()),
+    Act1 = zipper:left(Act0),
+    Act2 = zipper:right(Act1),
+    Act3 = zipper:set_value(Act2, 5),
+    Act4 = zipper:to_tree(Act3),
+    ?assertMatch(Exp, Act4).


### PR DESCRIPTION
This is more ore less a translation of xelixirs testsuite and an example which is more or less a translation of my elixir solution.

Difference to my elixir solution:

* The erlang translation does keep binary tree and zipper in a single module, due to the single module per file restriction.
* I used records in the erlang solution instead of maps.

I tried to not assume anything about the internal structure of the records and to only use function calls to construct the tree and zipper.

Also I am wondering if we should provide a skeleton-file which already has the following:

* incomplete `-type` for a `tree()` and `zipper()` type.
* `-spec`s for all functions called from the testsuite
* functionskelettons which have correct function names as well as carefully choosen names for arguments, but just returning `undefined`

Providing this could be another help in addition to the `hints`-folder.

So far this exercise is only implemented in elixir, and I am eager to see it elsewhere. It gave me a new view on datastructures and how to look at them. 