### PR TITLE
Clock tests

### DIFF
--- a/exercises/clock/clock.erl
+++ b/exercises/clock/clock.erl
@@ -1,0 +1,14 @@
+-module('clock').
+
+-export([create/2,
+  is_equal/2,
+  minutes_add/2,
+  to_string/1]).
+
+create(Hour, Minute) -> [].
+
+is_equal(Clock1, Clock2) -> [].
+
+minutes_add(Clock, Minutes) -> [].
+
+to_string(Clock) -> [].

--- a/exercises/clock/clock_tests.erl
+++ b/exercises/clock/clock_tests.erl
@@ -113,192 +113,80 @@ subtract_more_than_one_day_test() ->
 subtract_more_than_two_days_test() ->
   ?assertClockAdd("00:20", 2, 20, -3000).
 
-%%{
-%%   "equal": {
-%%      "description": [
-%%         "Construct two separate clocks, set times, test if they are equal."
-%%      ],
-%%      "cases": [
-%%         {
-%%            "description": "clocks with same time",
-%%            "clock1": {
-%%               "hour": 15,
-%%               "minute": 37
-%%            },
-%%            "clock2": {
-%%               "hour": 15,
-%%               "minute": 37
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks a minute apart",
-%%            "clock1": {
-%%               "hour": 15,
-%%               "minute": 36
-%%            },
-%%            "clock2": {
-%%               "hour": 15,
-%%               "minute": 37
-%%            },
-%%            "expected": false
-%%         },
-%%         {
-%%            "description": "clocks an hour apart",
-%%            "clock1": {
-%%               "hour": 14,
-%%               "minute": 37
-%%            },
-%%            "clock2": {
-%%               "hour": 15,
-%%               "minute": 37
-%%            },
-%%            "expected": false
-%%         },
-%%         {
-%%            "description": "clocks with hour overflow",
-%%            "clock1": {
-%%               "hour": 10,
-%%               "minute": 37
-%%            },
-%%            "clock2": {
-%%               "hour": 34,
-%%               "minute": 37
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with hour overflow by several days",
-%%            "clock1": {
-%%               "hour": 3,
-%%               "minute": 11
-%%            },
-%%            "clock2": {
-%%               "hour": 99,
-%%               "minute": 11
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative hour",
-%%            "clock1": {
-%%               "hour": 22,
-%%               "minute": 40
-%%            },
-%%            "clock2": {
-%%               "hour": -2,
-%%               "minute": 40
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative hour that wraps",
-%%            "clock1": {
-%%               "hour": 17,
-%%               "minute": 3
-%%            },
-%%            "clock2": {
-%%               "hour": -31,
-%%               "minute": 3
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative hour that wraps multiple times",
-%%            "clock1": {
-%%               "hour": 13,
-%%               "minute": 49
-%%            },
-%%            "clock2": {
-%%               "hour": -83,
-%%               "minute": 49
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with minute overflow",
-%%            "clock1": {
-%%               "hour": 0,
-%%               "minute": 1
-%%            },
-%%            "clock2": {
-%%               "hour": 0,
-%%               "minute": 1441
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with minute overflow by several days",
-%%            "clock1": {
-%%               "hour": 2,
-%%               "minute": 2
-%%            },
-%%            "clock2": {
-%%               "hour": 2,
-%%               "minute": 4322
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative minute",
-%%            "clock1": {
-%%               "hour": 2,
-%%               "minute": 40
-%%            },
-%%            "clock2": {
-%%               "hour": 3,
-%%               "minute": -20
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative minute that wraps",
-%%            "clock1": {
-%%               "hour": 4,
-%%               "minute": 10
-%%            },
-%%            "clock2": {
-%%               "hour": 5,
-%%               "minute": -1490
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative minute that wraps multiple times",
-%%            "clock1": {
-%%               "hour": 6,
-%%               "minute": 15
-%%            },
-%%            "clock2": {
-%%               "hour": 6,
-%%               "minute": -4305
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative hours and minutes",
-%%            "clock1": {
-%%               "hour": 7,
-%%               "minute": 32
-%%            },
-%%            "clock2": {
-%%               "hour": -12,
-%%               "minute": -268
-%%            },
-%%            "expected": true
-%%         },
-%%         {
-%%            "description": "clocks with negative hours and minutes that wrap",
-%%            "clock1": {
-%%               "hour": 18,
-%%               "minute": 7
-%%            },
-%%            "clock2": {
-%%               "hour": -54,
-%%               "minute": -11513
-%%            },
-%%            "expected": true
-%%         }
-%%      ]
-%%   }
-%%}
+
+equal_clocks_with_same_time_test() ->
+  Clock1 = clock:create(15, 37),
+  Clock2 = clock:create(15, 37),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_a_minute_apart_test() ->
+  Clock1 = clock:create(15, 36),
+  Clock2 = clock:create(15, 37),
+  ?assertNot(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_an_hour_apart_test() ->
+  Clock1 = clock:create(14, 37),
+  Clock2 = clock:create(15, 37),
+  ?assertNot(clock:is_equal(Clock1, Clock2)).
+
+
+equal_clocks_with_hour_overflow_test() ->
+  Clock1 = clock:create(10, 37),
+  Clock2 = clock:create(34, 37),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_hour_overflow_by_several_days_test() ->
+  Clock1 = clock:create(3, 11),
+  Clock2 = clock:create(99, 11),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_hour_test() ->
+  Clock1 = clock:create(22, 40),
+  Clock2 = clock:create(-2, 40),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_hour_that_wraps_test() ->
+  Clock1 = clock:create(17, 3),
+  Clock2 = clock:create(-31, 3),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_hour_that_wraps_multiple_times_test() ->
+  Clock1 = clock:create(13, 49),
+  Clock2 = clock:create(-83, 49),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_minute_overflow_test() ->
+  Clock1 = clock:create(0, 1),
+  Clock2 = clock:create(0, 1441),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_minute_overflow_by_several_days_test() ->
+  Clock1 = clock:create(2, 2),
+  Clock2 = clock:create(2, 4322),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_minute_test() ->
+  Clock1 = clock:create(2, 40),
+  Clock2 = clock:create(3, -20),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_minute_that_wraps_test() ->
+  Clock1 = clock:create(4, 10),
+  Clock2 = clock:create(5, -1490),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_minute_that_wraps_multiple_times_test() ->
+  Clock1 = clock:create(6, 15),
+  Clock2 = clock:create(6, -4305),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_hours_and_minutes_test() ->
+  Clock1 = clock:create(7, 32),
+  Clock2 = clock:create(-12, -268),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+
+equal_clocks_with_negative_hours_and_minutes_that_wrap_test() ->
+  Clock1 = clock:create(18, 7),
+  Clock2 = clock:create(-54, -11513),
+  ?assert(clock:is_equal(Clock1, Clock2)).
+

--- a/exercises/clock/clock_tests.erl
+++ b/exercises/clock/clock_tests.erl
@@ -1,37 +1,370 @@
--module( clock_tests ).
--include_lib( "eunit/include/eunit.hrl" ).
+-module('clock_tests').
+-include_lib("eunit/include/eunit.hrl").
 
-create_test() ->
-  clock:create( 0, 0 ),
-  ?assertException( error, function_clause, clock:create(-1, 0) ),
-  ?assertException( error, function_clause, clock:create(0, -1) ),
-  ?assertException( error, function_clause, clock:create(24, 0) ),
-  ?assertException( error, function_clause, clock:create(0, 60) ).
+-define(assertClockString(String, Hour, Minute), ?assertEqual(String, clock:to_string(clock:create( Hour, Minute)))).
 
-to_string_test() ->
-  ?assert( "00:00" =:= clock:to_string(clock:create(0, 0)) ),
-  ?assert( "00:01" =:= clock:to_string(clock:create(0, 1)) ),
-  ?assert( "01:00" =:= clock:to_string(clock:create(1, 0)) ),
-  ?assert( "23:59" =:= clock:to_string(clock:create(23, 59)) ).
+create_on_the_hour_test() ->
+  ?assertClockString("08:00", 8, 0).
 
-is_equal_test() ->
-  Clock1 = clock:create( 1, 0 ),
-  Clock2 = clock:create( 1, 0 ),
-  ?assert( clock:is_equal(Clock1, Clock2) ).
+create_past_the_hour_test() ->
+  ?assertClockString("11:09", 11, 9).
 
-minutes_add_test() ->
-  Clock1 = clock:create( 1, 0 ),
-  Clock2 = clock:minutes_add( Clock1, 10 ),
-  ?assert( "01:10" =:= clock:to_string(Clock2) ),
-  Clock3 = clock:minutes_add( Clock1, 4 * 60 + 50 ),
-  ?assert( "05:50" =:= clock:to_string(Clock3) ),
-  Clock4 = clock:create( 23, 59 ),
-  Clock5 = clock:minutes_add( Clock4, 1 ),
-  ?assert( "00:00" =:= clock:to_string(Clock5) ).
+create_midnight_is_zero_hours_test() ->
+  ?assertClockString("00:00", 24, 0).
 
-minutes_delete_test() ->
-  Clock1 = clock:create( 1, 0 ),
-  Clock2 = clock:minutes_delete( Clock1, 10 ),
-  ?assert( "00:50" =:= clock:to_string(Clock2) ),
-  Clock3 = clock:minutes_delete( Clock1, 4 * 60 + 50 ),
-  ?assert( "20:10" =:= clock:to_string(Clock3) ).
+create_hour_rolls_over_test() ->
+  ?assertClockString("01:00", 25, 0).
+
+create_hour_rolls_over_continuously_test() ->
+  ?assertClockString("04:00", 100, 0).
+
+create_sixty_minutes_is_next_hour_test() ->
+  ?assertClockString("02:00", 1, 60).
+
+create_minutes_roll_over_test() ->
+  ?assertClockString("02:40", 0, 160).
+
+create_minutes_roll_over_continuously_test() ->
+  ?assertClockString("04:43", 0, 1723).
+
+create_hour_and_minutes_roll_over_test() ->
+  ?assertClockString("03:40", 25, 160).
+
+create_hour_and_minutes_roll_over_continuously_test() ->
+  ?assertClockString("11:01", 201, 3001).
+
+create_hour_and_minutes_roll_over_to_exactly_midnight_test() ->
+  ?assertClockString("00:00", 72, 8640).
+
+create_negative_hour_test() ->
+  ?assertClockString("23:15", -1, 15).
+
+create_negative_hour_rolls_over_test() ->
+  ?assertClockString("23:00", -25, 0).
+
+create_negative_hour_rolls_over_continuously_test() ->
+  ?assertClockString("05:00", -91, 0).
+
+create_negative_minutes_test() ->
+  ?assertClockString("00:20", 1, -40).
+
+create_negative_minutes_roll_over_test() ->
+  ?assertClockString("22:20", 1, -160).
+
+create_negative_minutes_roll_over_continuously_test() ->
+  ?assertClockString("16:40", 1, -4820).
+
+create_negative_hour_and_minutes_both_roll_over_test() ->
+  ?assertClockString("20:20", -25, -160).
+
+create_negative_hour_and_minutes_both_roll_over_continuously_test() ->
+  ?assertClockString("22:10", -121, -5810).
+
+%%{
+%%   "add": {
+%%      "description": [
+%%         "Test adding and subtracting minutes."
+%%      ],
+%%      "cases": [
+%%         {
+%%            "description": "add minutes",
+%%            "hour": 10,
+%%            "minute": 0,
+%%            "add": 3,
+%%            "expected": "10:03"
+%%         },
+%%         {
+%%            "description": "add no minutes",
+%%            "hour": 6,
+%%            "minute": 41,
+%%            "add": 0,
+%%            "expected": "06:41"
+%%         },
+%%         {
+%%            "description": "add to next hour",
+%%            "hour": 0,
+%%            "minute": 45,
+%%            "add": 40,
+%%            "expected": "01:25"
+%%         },
+%%         {
+%%            "description": "add more than one hour",
+%%            "hour": 10,
+%%            "minute": 0,
+%%            "add": 61,
+%%            "expected": "11:01"
+%%         },
+%%         {
+%%            "description": "add more than two hours with carry",
+%%            "hour": 0,
+%%            "minute": 45,
+%%            "add": 160,
+%%            "expected": "03:25"
+%%         },
+%%         {
+%%            "description": "add across midnight",
+%%            "hour": 23,
+%%            "minute": 59,
+%%            "add": 2,
+%%            "expected": "00:01"
+%%         },
+%%         {
+%%            "description": "add more than one day (1500 min = 25 hrs)",
+%%            "hour": 5,
+%%            "minute": 32,
+%%            "add": 1500,
+%%            "expected": "06:32"
+%%         },
+%%         {
+%%            "description": "add more than two days",
+%%            "hour": 1,
+%%            "minute": 1,
+%%            "add": 3500,
+%%            "expected": "11:21"
+%%         },
+%%         {
+%%            "description": "subtract minutes",
+%%            "hour": 10,
+%%            "minute": 3,
+%%            "add": -3,
+%%            "expected": "10:00"
+%%         },
+%%         {
+%%            "description": "subtract to previous hour",
+%%            "hour": 10,
+%%            "minute": 3,
+%%            "add": -30,
+%%            "expected": "09:33"
+%%         },
+%%         {
+%%            "description": "subtract more than an hour",
+%%            "hour": 10,
+%%            "minute": 3,
+%%            "add": -70,
+%%            "expected": "08:53"
+%%         },
+%%         {
+%%            "description": "subtract across midnight",
+%%            "hour": 0,
+%%            "minute": 3,
+%%            "add": -4,
+%%            "expected": "23:59"
+%%         },
+%%         {
+%%            "description": "subtract more than two hours",
+%%            "hour": 0,
+%%            "minute": 0,
+%%            "add": -160,
+%%            "expected": "21:20"
+%%         },
+%%         {
+%%            "description": "subtract more than two hours with borrow",
+%%            "hour": 6,
+%%            "minute": 15,
+%%            "add": -160,
+%%            "expected": "03:35"
+%%         },
+%%         {
+%%            "description": "subtract more than one day (1500 min = 25 hrs)",
+%%            "hour": 5,
+%%            "minute": 32,
+%%            "add": -1500,
+%%            "expected": "04:32"
+%%         },
+%%         {
+%%            "description": "subtract more than two days",
+%%            "hour": 2,
+%%            "minute": 20,
+%%            "add": -3000,
+%%            "expected": "00:20"
+%%         }
+%%      ]
+%%   },
+%%   "equal": {
+%%      "description": [
+%%         "Construct two separate clocks, set times, test if they are equal."
+%%      ],
+%%      "cases": [
+%%         {
+%%            "description": "clocks with same time",
+%%            "clock1": {
+%%               "hour": 15,
+%%               "minute": 37
+%%            },
+%%            "clock2": {
+%%               "hour": 15,
+%%               "minute": 37
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks a minute apart",
+%%            "clock1": {
+%%               "hour": 15,
+%%               "minute": 36
+%%            },
+%%            "clock2": {
+%%               "hour": 15,
+%%               "minute": 37
+%%            },
+%%            "expected": false
+%%         },
+%%         {
+%%            "description": "clocks an hour apart",
+%%            "clock1": {
+%%               "hour": 14,
+%%               "minute": 37
+%%            },
+%%            "clock2": {
+%%               "hour": 15,
+%%               "minute": 37
+%%            },
+%%            "expected": false
+%%         },
+%%         {
+%%            "description": "clocks with hour overflow",
+%%            "clock1": {
+%%               "hour": 10,
+%%               "minute": 37
+%%            },
+%%            "clock2": {
+%%               "hour": 34,
+%%               "minute": 37
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with hour overflow by several days",
+%%            "clock1": {
+%%               "hour": 3,
+%%               "minute": 11
+%%            },
+%%            "clock2": {
+%%               "hour": 99,
+%%               "minute": 11
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative hour",
+%%            "clock1": {
+%%               "hour": 22,
+%%               "minute": 40
+%%            },
+%%            "clock2": {
+%%               "hour": -2,
+%%               "minute": 40
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative hour that wraps",
+%%            "clock1": {
+%%               "hour": 17,
+%%               "minute": 3
+%%            },
+%%            "clock2": {
+%%               "hour": -31,
+%%               "minute": 3
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative hour that wraps multiple times",
+%%            "clock1": {
+%%               "hour": 13,
+%%               "minute": 49
+%%            },
+%%            "clock2": {
+%%               "hour": -83,
+%%               "minute": 49
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with minute overflow",
+%%            "clock1": {
+%%               "hour": 0,
+%%               "minute": 1
+%%            },
+%%            "clock2": {
+%%               "hour": 0,
+%%               "minute": 1441
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with minute overflow by several days",
+%%            "clock1": {
+%%               "hour": 2,
+%%               "minute": 2
+%%            },
+%%            "clock2": {
+%%               "hour": 2,
+%%               "minute": 4322
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative minute",
+%%            "clock1": {
+%%               "hour": 2,
+%%               "minute": 40
+%%            },
+%%            "clock2": {
+%%               "hour": 3,
+%%               "minute": -20
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative minute that wraps",
+%%            "clock1": {
+%%               "hour": 4,
+%%               "minute": 10
+%%            },
+%%            "clock2": {
+%%               "hour": 5,
+%%               "minute": -1490
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative minute that wraps multiple times",
+%%            "clock1": {
+%%               "hour": 6,
+%%               "minute": 15
+%%            },
+%%            "clock2": {
+%%               "hour": 6,
+%%               "minute": -4305
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative hours and minutes",
+%%            "clock1": {
+%%               "hour": 7,
+%%               "minute": 32
+%%            },
+%%            "clock2": {
+%%               "hour": -12,
+%%               "minute": -268
+%%            },
+%%            "expected": true
+%%         },
+%%         {
+%%            "description": "clocks with negative hours and minutes that wrap",
+%%            "clock1": {
+%%               "hour": 18,
+%%               "minute": 7
+%%            },
+%%            "clock2": {
+%%               "hour": -54,
+%%               "minute": -11513
+%%            },
+%%            "expected": true
+%%         }
+%%      ]
+%%   }
+%%}

--- a/exercises/clock/clock_tests.erl
+++ b/exercises/clock/clock_tests.erl
@@ -3,6 +3,8 @@
 
 -define(assertClockString(String, Hour, Minute), ?assertEqual(String, clock:to_string(clock:create( Hour, Minute)))).
 
+-define(assertClockAdd(String, Hour, Minute, Add), ?assertEqual(String, clock:to_string(clock:minutes_add(clock:create(Hour, Minute), Add)))).
+
 create_on_the_hour_test() ->
   ?assertClockString("08:00", 8, 0).
 
@@ -60,126 +62,58 @@ create_negative_hour_and_minutes_both_roll_over_test() ->
 create_negative_hour_and_minutes_both_roll_over_continuously_test() ->
   ?assertClockString("22:10", -121, -5810).
 
+
+
+add_minutes_test() ->
+  ?assertClockAdd("10:03", 10, 0, 3).
+
+add_no_minutes_test() ->
+  ?assertClockAdd("06:41", 6, 41, 0).
+
+add_to_next_hour_test() ->
+  ?assertClockAdd("01:25", 0, 45, 40).
+
+add_more_than_one_hour_test() ->
+  ?assertClockAdd("11:01", 10, 0, 61).
+
+add_more_than_two_hours_with_carry_test() ->
+  ?assertClockAdd("03:25", 0, 45, 160).
+
+
+add_across_midnight_test() ->
+  ?assertClockAdd("00:01", 23, 59, 2).
+
+add_more_than_one_day_test() ->
+  ?assertClockAdd("06:32", 5, 32, 1500). %% 1500 min => 25 h
+
+add_more_than_two_days_test() ->
+  ?assertClockAdd("11:21", 1, 1, 3500).
+
+subtract_minutes_test() ->
+  ?assertClockAdd("10:00", 10, 3, -3).
+
+subtract_to_previous_hour_test() ->
+  ?assertClockAdd("09:33", 10, 3, -30).
+
+subtract_more_than_an_hour_test() ->
+  ?assertClockAdd("08:53", 10, 3, -70).
+
+subtract_across_midnight_test() ->
+  ?assertClockAdd("23:59", 0, 3, -4).
+
+subtract_more_than_two_hours_test() ->
+  ?assertClockAdd("21:20", 0, 0, -160).
+
+subtract_more_than_two_hours_with_borrow_test() ->
+  ?assertClockAdd("03:35", 6, 15, -160).
+
+subtract_more_than_one_day_test() ->
+  ?assertClockAdd("04:32", 5, 32, -1500). %%1500 min => 25 h
+
+subtract_more_than_two_days_test() ->
+  ?assertClockAdd("00:20", 2, 20, -3000).
+
 %%{
-%%   "add": {
-%%      "description": [
-%%         "Test adding and subtracting minutes."
-%%      ],
-%%      "cases": [
-%%         {
-%%            "description": "add minutes",
-%%            "hour": 10,
-%%            "minute": 0,
-%%            "add": 3,
-%%            "expected": "10:03"
-%%         },
-%%         {
-%%            "description": "add no minutes",
-%%            "hour": 6,
-%%            "minute": 41,
-%%            "add": 0,
-%%            "expected": "06:41"
-%%         },
-%%         {
-%%            "description": "add to next hour",
-%%            "hour": 0,
-%%            "minute": 45,
-%%            "add": 40,
-%%            "expected": "01:25"
-%%         },
-%%         {
-%%            "description": "add more than one hour",
-%%            "hour": 10,
-%%            "minute": 0,
-%%            "add": 61,
-%%            "expected": "11:01"
-%%         },
-%%         {
-%%            "description": "add more than two hours with carry",
-%%            "hour": 0,
-%%            "minute": 45,
-%%            "add": 160,
-%%            "expected": "03:25"
-%%         },
-%%         {
-%%            "description": "add across midnight",
-%%            "hour": 23,
-%%            "minute": 59,
-%%            "add": 2,
-%%            "expected": "00:01"
-%%         },
-%%         {
-%%            "description": "add more than one day (1500 min = 25 hrs)",
-%%            "hour": 5,
-%%            "minute": 32,
-%%            "add": 1500,
-%%            "expected": "06:32"
-%%         },
-%%         {
-%%            "description": "add more than two days",
-%%            "hour": 1,
-%%            "minute": 1,
-%%            "add": 3500,
-%%            "expected": "11:21"
-%%         },
-%%         {
-%%            "description": "subtract minutes",
-%%            "hour": 10,
-%%            "minute": 3,
-%%            "add": -3,
-%%            "expected": "10:00"
-%%         },
-%%         {
-%%            "description": "subtract to previous hour",
-%%            "hour": 10,
-%%            "minute": 3,
-%%            "add": -30,
-%%            "expected": "09:33"
-%%         },
-%%         {
-%%            "description": "subtract more than an hour",
-%%            "hour": 10,
-%%            "minute": 3,
-%%            "add": -70,
-%%            "expected": "08:53"
-%%         },
-%%         {
-%%            "description": "subtract across midnight",
-%%            "hour": 0,
-%%            "minute": 3,
-%%            "add": -4,
-%%            "expected": "23:59"
-%%         },
-%%         {
-%%            "description": "subtract more than two hours",
-%%            "hour": 0,
-%%            "minute": 0,
-%%            "add": -160,
-%%            "expected": "21:20"
-%%         },
-%%         {
-%%            "description": "subtract more than two hours with borrow",
-%%            "hour": 6,
-%%            "minute": 15,
-%%            "add": -160,
-%%            "expected": "03:35"
-%%         },
-%%         {
-%%            "description": "subtract more than one day (1500 min = 25 hrs)",
-%%            "hour": 5,
-%%            "minute": 32,
-%%            "add": -1500,
-%%            "expected": "04:32"
-%%         },
-%%         {
-%%            "description": "subtract more than two days",
-%%            "hour": 2,
-%%            "minute": 20,
-%%            "add": -3000,
-%%            "expected": "00:20"
-%%         }
-%%      ]
-%%   },
 %%   "equal": {
 %%      "description": [
 %%         "Construct two separate clocks, set times, test if they are equal."

--- a/exercises/clock/example.erl
+++ b/exercises/clock/example.erl
@@ -1,4 +1,4 @@
--module(clock).
+-module('clock').
 
 -export([create/2,
          is_equal/2,
@@ -6,9 +6,15 @@
          minutes_delete/2,
          to_string/1] ).
 
+-record(?MODULE, {normalized}).
 
-create(Hour,Minutes) when Hour >= 0, Hour < 24, Minutes >= 0, Minutes < 60 ->
-  {Hour, Minutes}.
+-define(HOURS_PER_DAY, 24).
+-define(MINUTES_PER_HOUR, 60).
+-define(MINUTES_PER_DAY, (?HOURS_PER_DAY * ?MINUTES_PER_HOUR)).
+
+
+create(Hour,Minutes) ->
+  #?MODULE{normalized = mod(Hour * ?MINUTES_PER_HOUR + Minutes, ?MINUTES_PER_DAY)}.
 
 is_equal(C, C) ->
   true;
@@ -35,5 +41,11 @@ minutes2hour_minutes(Mraw) ->
   M = Mraw rem day_minutes(),
   { M div 60, M rem 60}.
 
-to_string({Hour,Minutes}) ->
+to_string(#?MODULE{normalized = Mins}) ->
+  Hour = Mins div ?MINUTES_PER_HOUR,
+  Minutes = Mins rem ?MINUTES_PER_HOUR,
   lists:flatten( io_lib:format("~2.10.0b:~2.10.0b", [Hour, Minutes]) ).
+
+mod(X,Y) when X > 0 -> X rem Y;
+mod(X,Y) when X < 0 -> Y + X rem Y;
+mod(0,Y) -> 0.

--- a/exercises/clock/example.erl
+++ b/exercises/clock/example.erl
@@ -1,10 +1,9 @@
 -module('clock').
 
 -export([create/2,
-         is_equal/2,
-         minutes_add/2,
-         minutes_delete/2,
-         to_string/1] ).
+  is_equal/2,
+  minutes_add/2,
+  to_string/1]).
 
 -record(?MODULE, {normalized}).
 
@@ -13,7 +12,7 @@
 -define(MINUTES_PER_DAY, (?HOURS_PER_DAY * ?MINUTES_PER_HOUR)).
 
 
-create(Hour,Minutes) ->
+create(Hour, Minutes) ->
   #?MODULE{normalized = mod(Hour * ?MINUTES_PER_HOUR + Minutes, ?MINUTES_PER_DAY)}.
 
 is_equal(C, C) ->
@@ -21,31 +20,15 @@ is_equal(C, C) ->
 is_equal(_, _) ->
   false.
 
-minutes_add(#?MODULE{normalized = Mins}, Minutes ) ->
+minutes_add(#?MODULE{normalized = Mins}, Minutes) ->
   TotalMinutes = mod(Mins + Minutes, ?MINUTES_PER_DAY),
   #?MODULE{normalized = TotalMinutes}.
-
-
-minutes_delete( Clock, Minutes) ->
-  TotalMinutes =  (hour_minutes2minutes(Clock) + day_minutes() - Minutes) rem day_minutes(),
-  minutes2hour_minutes(TotalMinutes).
-
-
-day_minutes() ->
-  24*60.
-
-hour_minutes2minutes({H,M}) ->
-  60*H + M.
-
-minutes2hour_minutes(Mraw) ->
-  M = Mraw rem day_minutes(),
-  { M div 60, M rem 60}.
 
 to_string(#?MODULE{normalized = Mins}) ->
   Hour = Mins div ?MINUTES_PER_HOUR,
   Minutes = Mins rem ?MINUTES_PER_HOUR,
-  lists:flatten( io_lib:format("~2.10.0b:~2.10.0b", [Hour, Minutes]) ).
+  lists:flatten(io_lib:format("~2.10.0b:~2.10.0b", [Hour, Minutes])).
 
-mod(X,Y) when X > 0 -> X rem Y;
-mod(X,Y) when X < 0 -> Y + X rem Y;
-mod(0,Y) -> 0.
+mod(X, Y) when X > 0 -> X rem Y;
+mod(X, Y) when X < 0 -> Y + X rem Y;
+mod(0, _Y) -> 0.

--- a/exercises/clock/example.erl
+++ b/exercises/clock/example.erl
@@ -21,9 +21,9 @@ is_equal(C, C) ->
 is_equal(_, _) ->
   false.
 
-minutes_add( Clock, Minutes ) ->
-  TotalMinutes =  (hour_minutes2minutes(Clock) + Minutes) rem day_minutes(),
-  minutes2hour_minutes(TotalMinutes).
+minutes_add(#?MODULE{normalized = Mins}, Minutes ) ->
+  TotalMinutes = mod(Mins + Minutes, ?MINUTES_PER_DAY),
+  #?MODULE{normalized = TotalMinutes}.
 
 
 minutes_delete( Clock, Minutes) ->


### PR DESCRIPTION
This does implement the current version of common test data for `clock`.

FIX #98 