### PR TITLE
Lsp canonical

### DIFF
--- a/exercises/largest-series-product/example.erl
+++ b/exercises/largest-series-product/example.erl
@@ -1,19 +1,26 @@
--module( largest_series_product ).
+-module('largest_series_product').
 
--export( [from_string/2 ] ).
+-export([lsp/2]).
 
-from_string( String, N ) -> from_string( erlang:length(String), String, N ).
+-define(is_digit(C), ((C >= $0) and (C =< $9))).
+
+lsp(_String, N) when N < 0 -> error;
+lsp(String, N) -> lsp(erlang:length(String), String, N).
 
 
 
-from_string( Length, String, N ) when Length >= N ->
-  Sets = sets( Length, N, String ),
-  lists:max( [product(X) || X <- Sets] ).
+lsp(Length, _String, N) when Length < N -> error;
+lsp(Length, String, N) ->
+  Sets = sets(Length, N, String),
+  lists:max([product(X) || X <- Sets]).
 
-product( Set ) -> lists:foldl( fun product/2, 1, Set ).
-product( C, Acc ) when C >= $0, C =< $9 -> (C - $0) * Acc.
+product(Set) -> lists:foldl(fun product/2, 1, Set).
 
-sets( Length, Width, [_ | T]=String ) when Length > Width ->
-  Set = lists:sublist( String, Width ),
-  [Set | sets( Length - 1, Width, T )];
-sets( _Length, _Width, String ) -> [String].
+product(_C, error) -> error;
+product(C, _Acc) when not ?is_digit(C) -> error;
+product(C, Acc) -> (C - $0) * Acc.
+
+sets(Length, Width, [_ | T] = String) when Length > Width ->
+  Set = lists:sublist(String, Width),
+  [Set | sets(Length - 1, Width, T)];
+sets(_Length, _Width, String) -> [String].

--- a/exercises/largest-series-product/largest_series_product.erl
+++ b/exercises/largest-series-product/largest_series_product.erl
@@ -1,0 +1,5 @@
+-module('largest_series_product').
+
+-export([lsp/2]).
+
+lsp(String, Span) -> [].

--- a/exercises/largest-series-product/largest_series_product_tests.erl
+++ b/exercises/largest-series-product/largest_series_product_tests.erl
@@ -1,20 +1,54 @@
--module( largest_series_product_tests ).
+-module('largest_series_product_tests').
 -include_lib("eunit/include/eunit.hrl").
 
-three_test() -> ?assert( 504 =:= largest_series_product:from_string("0123456789", 3) ).
 
-five_test() -> ?assert( 15120 =:= largest_series_product:from_string("0123456789", 5) ).
+can_find_the_largest_product_of_2_with_numbers_in_order_test() ->
+  ?assertEqual(72, largest_series_product:lsp("0123456789", 2)).
 
-six_test() -> ?assert( 23520 =:= largest_series_product:from_string("73167176531330624919225119674426574742355349194934", 6) ).
+can_find_the_largest_product_of_2_test() ->
+  ?assertEqual(48, largest_series_product:lsp("576802143", 2)).
 
-all_zeroes_test() -> ?assert( 0 =:= largest_series_product:from_string("0000", 2) ).
+finds_the_largest_product_if_span_equals_length_test() ->
+  ?assertEqual(18, largest_series_product:lsp("29", 2)).
 
-all_contain_zeroes_test() -> ?assert( 0 =:= largest_series_product:from_string("99099", 3) ).
+can_find_the_largest_product_of_3_with_numbers_in_order_test() ->
+  ?assertEqual(504, largest_series_product:lsp("0123456789", 3)).
 
-too_long_test() -> ?assertError(_, largest_series_product:from_string("123", 4) ).
+can_find_the_largest_product_of_3_test() ->
+  ?assertEqual(270, largest_series_product:lsp("1027839564", 3)).
 
-empty_product_test() -> ?assert( 1 =:= largest_series_product:from_string("", 0) ).
+can_find_the_largest_product_of_5_with_numbers_in_order_test() ->
+  ?assertEqual(15120, largest_series_product:lsp("0123456789", 5)).
 
-nonempty_string_empty_product_test() -> ?assert( 1 =:= largest_series_product:from_string("123", 0) ).
+can_find_the_largest_product_of_a_big_number_test() ->
+  ?assertEqual(23520, largest_series_product:lsp("73167176531330624919225119674426574742355349194934", 6)).
 
-empty_string_nonzero_span_test() -> ?assertError(_, largest_series_product:from_string("", 1) ).
+can_find_the_largest_product_of_a_big_number_ii_test() ->
+  ?assertEqual(28350, largest_series_product:lsp("52677741234314237566414902593461595376319419139427", 6)).
+
+can_find_the_largest_product_of_a_big_number_project_euler_test() ->
+  ?assertEqual(23514624000, largest_series_product:lsp("7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450", 13)).
+
+reports_zero_if_the_only_digits_are_zero_test() ->
+  ?assertEqual(0, largest_series_product:lsp("0000", 2)).
+
+reports_zero_if_all_spans_include_zero_test() ->
+  ?assertEqual(0, largest_series_product:lsp("99099", 3)).
+
+rejects_span_longer_than_string_length_test() ->
+  ?assertMatch(error, largest_series_product:lsp("123", 4)).
+
+reports_1_for_empty_string_and_empty_product_0_span_test() ->
+  ?assertEqual(1, largest_series_product:lsp("", 0)).
+
+reports_1_for_nonempty_string_and_empty_product_0_span_test() ->
+  ?assertEqual(1, largest_series_product:lsp("123", 0)).
+
+rejects_empty_string_and_nonzero_span_test() ->
+  ?assertMatch(error, largest_series_product:lsp("", 1)).
+
+rejects_invalid_character_in_digits_test() ->
+  ?assertMatch(error, largest_series_product:lsp("1234a5", 2)).
+
+rejects_negative_span_test() ->
+  ?assertMatch(error, largest_series_product:lsp("12345", -1)).


### PR DESCRIPTION
Implements canonical test-data for LSP.

FIX #91 