### PR TITLE
Remove unused import

### DIFF
--- a/exercises/sum-of-multiples/sum_of_multiples_tests.erl
+++ b/exercises/sum-of-multiples/sum_of_multiples_tests.erl
@@ -1,5 +1,5 @@
 -module(sum_of_multiples_tests).
--import(sum_of_multiples, [sumOfMultiplesDefault/1, sumOfMultiples/2]).
+-import(sum_of_multiples, [sumOfMultiples/2]).
 
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
The function `sumOfMultiplesDefault` isn't used anymore (see #92), so it shouldn't be imported in the test suite.